### PR TITLE
Remove reference to Scala's Arrays.class

### DIFF
--- a/src/main/java/two/davincing/ProxyBase.java
+++ b/src/main/java/two/davincing/ProxyBase.java
@@ -3,12 +3,12 @@
 package two.davincing;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraftforge.common.MinecraftForge;
-import scala.actors.threadpool.Arrays;
 import two.davincing.item.CanvasItem;
 import two.davincing.item.ChiselItem;
 import two.davincing.item.CopygunItem;


### PR DESCRIPTION
scala.actors.threadpool.Arrays looks almost exactly like java.util.Arrays except that it isn't shipped with Forge's universal builds. This crashes the game when someone tries to refer to it.
